### PR TITLE
Enable cross-class BLE scan collection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
         android:usesPermissionFlags="neverForLocation" />
     
-    <!-- Location permissions (required for Bluetooth scanning on all versions) -->
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Location permission (required for Bluetooth scanning on all versions) -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
         android:usesPermissionFlags="neverForLocation" />
     
-    <!-- Location permission (required for Bluetooth scanning on all versions) -->
+    <!-- Location permissions (required for Bluetooth scanning on all versions) -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,10 +2,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" 
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" 
+        android:maxSdkVersion="30" />
+    
+    <!-- Bluetooth permissions for Android 12+ -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
+        android:usesPermissionFlags="neverForLocation" />
+    
+    <!-- Location permissions (required for Bluetooth scanning on all versions) -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -104,8 +104,8 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         val resultList = scannedDeviceCache.values.toList()
         printLog("1 emitForInsertInRoom result: ${resultList.size}","uicheck")
         printLog("1 emitForInsertInRoom : $resultList","uicheck")
-        scannedDeviceRepository.insertDeviceList(resultList)
-        /*_scannedDevices.emit(resultList)*/
+        // Emit to the SharedFlow so other collectors can receive the data
+        _scannedDevices.emit(resultList)
         scannedDeviceCache.clear()
     }
 

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -104,8 +104,14 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         val resultList = scannedDeviceCache.values.toList()
         printLog("1 emitForInsertInRoom result: ${resultList.size}","uicheck")
         printLog("1 emitForInsertInRoom : $resultList","uicheck")
-        // Emit to the SharedFlow so other collectors can receive the data
+        
+        // Emit to the SharedFlow so UseCase can collect and insert to database
+        printLog("About to emit to SharedFlow with ${resultList.size} devices", "emission_debug")
         _scannedDevices.emit(resultList)
+        printLog("Successfully emitted to SharedFlow", "emission_debug")
+        
+        // Comment out direct database insertion - let the UseCase handle it
+        // scannedDeviceRepository.insertDeviceList(resultList)
         scannedDeviceCache.clear()
     }
 

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -86,12 +86,6 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         // Cancel previous job if any
         scanJob?.cancel()
         
-        // Emit an initial empty list to test the flow connection
-        appScope.launch {
-            printLog("Emitting initial test value to verify flow connection", "emission_debug")
-            _scannedDevices.emit(emptyList())
-        }
-        
         scanJob = appScope.launch {
             while (isActive) {
                 // Start scanning

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -9,8 +9,8 @@ import com.example.bluetoothtracker.data.model.BluetoothScanResult
 import com.example.bluetoothtracker.di.ApplicationScope
 import com.example.bluetoothtracker.domain.repository.ScannedDeviceRepository
 import com.example.bluetoothtracker.presentation.utils.printLog
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 
+@Singleton
 class BluetoothDeviceTrackerImpl @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope,
     private val bluetoothAdapter: BluetoothAdapter?,

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -87,6 +87,11 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         scanJob?.cancel()
         
         scanJob = appScope.launch {
+            // Wait 5 seconds to ensure collector is definitely running
+            printLog("Waiting 5 seconds to ensure collector is ready...", "emission_debug")
+            delay(5000)
+            printLog("5 seconds passed, starting actual scanning now", "emission_debug")
+            
             while (isActive) {
                 // Start scanning
                 bluetoothLeScanner?.startScan(scanCallback)

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -3,6 +3,7 @@ package com.example.bluetoothtracker.data.datasource
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanCallback.*
 import android.content.Context
 import com.example.bluetoothtracker.data.mapper.toEntityList
 import com.example.bluetoothtracker.data.model.BluetoothScanResult
@@ -50,16 +51,23 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
 
         override fun onScanFailed(errorCode: Int) {
             super.onScanFailed(errorCode)
-            printLog("Scan error $errorCode")
+            printLog("❌ Scan FAILED with error code: $errorCode", "scanDebug")
+            when (errorCode) {
+                SCAN_FAILED_ALREADY_STARTED -> printLog("SCAN_FAILED_ALREADY_STARTED", "scanDebug")
+                SCAN_FAILED_APPLICATION_REGISTRATION_FAILED -> printLog("SCAN_FAILED_APPLICATION_REGISTRATION_FAILED", "scanDebug")
+                SCAN_FAILED_FEATURE_UNSUPPORTED -> printLog("SCAN_FAILED_FEATURE_UNSUPPORTED", "scanDebug")
+                SCAN_FAILED_INTERNAL_ERROR -> printLog("SCAN_FAILED_INTERNAL_ERROR", "scanDebug")
+                SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES -> printLog("SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES", "scanDebug")
+            }
             stop()
         }
 
         @SuppressLint("MissingPermission")
         override fun onScanResult(callbackType: Int, result: android.bluetooth.le.ScanResult?) {
-            printLog("onScanResult")
+            printLog("✅ onScanResult called!", "scanDebug")
             super.onScanResult(callbackType, result)
             result?.let { scanResult ->
-                printLog("onScanResult $scanResult")
+                printLog("📱 Found device: ${scanResult.device.name ?: "Unknown"} - ${scanResult.device.address} - RSSI: ${scanResult.rssi}", "scanDebug")
 
                 val mac = scanResult.device.address ?: return
                 val device = BluetoothScanResult(
@@ -83,21 +91,39 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
 
     @SuppressLint("MissingPermission")
     override fun startScan() {
-        printLog("startDiscovery")
+        printLog("🚀 Starting Bluetooth LE scan...", "scanDebug")
+        
+        // Check if Bluetooth is enabled
+        if (bluetoothAdapter?.isEnabled != true) {
+            printLog("❌ Bluetooth is not enabled!", "scanDebug")
+            return
+        }
+        
+        // Check if scanner is available
+        if (bluetoothLeScanner == null) {
+            printLog("❌ BluetoothLeScanner is null!", "scanDebug")
+            return
+        }
+        
+        printLog("✅ Bluetooth enabled, scanner available", "scanDebug")
+        
         // Cancel previous job if any
         scanJob?.cancel()
         
         scanJob = appScope.launch {
             // Wait 5 seconds to ensure collector is definitely running
-            printLog("Waiting 5 seconds to ensure collector is ready...", "emission_debug")
+            printLog("⏳ Waiting 5 seconds to ensure collector is ready...", "scanDebug")
             delay(5000)
-            printLog("5 seconds passed, starting actual scanning now", "emission_debug")
+            printLog("✅ 5 seconds passed, starting actual scanning now", "scanDebug")
             
             while (isActive) {
                 // Start scanning
+                printLog("🔍 Starting BLE scan...", "scanDebug")
                 bluetoothLeScanner?.startScan(scanCallback)
                 delay(scanPeriod) // scan for 10 seconds
-                printLog("result: ${scannedDeviceCache.values}")
+                printLog("🛑 Stopping BLE scan...", "scanDebug")
+                printLog("📊 Scan results: ${scannedDeviceCache.size} devices found", "scanDebug")
+                printLog("📋 Device list: ${scannedDeviceCache.values}", "scanDebug")
                 // Stop scanning
                 bluetoothLeScanner?.stopScan(scanCallback)
                 emitForInsertInRoom()

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/BluetoothDeviceTrackerImpl.kt
@@ -37,7 +37,7 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
-    val scannedDevices: SharedFlow<List<BluetoothScanResult>> = _scannedDevices
+    val scannedDevices: SharedFlow<List<BluetoothScanResult>> = _scannedDevices.asSharedFlow()
     private val scannedDeviceCache = mutableMapOf<String, BluetoothScanResult>()
 
     private var scanJob: Job? = null
@@ -85,6 +85,13 @@ class BluetoothDeviceTrackerImpl @Inject constructor(
         printLog("startDiscovery")
         // Cancel previous job if any
         scanJob?.cancel()
+        
+        // Emit an initial empty list to test the flow connection
+        appScope.launch {
+            printLog("Emitting initial test value to verify flow connection", "emission_debug")
+            _scannedDevices.emit(emptyList())
+        }
+        
         scanJob = appScope.launch {
             while (isActive) {
                 // Start scanning

--- a/app/src/main/java/com/example/bluetoothtracker/data/datasource/ScannedDeviceLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/datasource/ScannedDeviceLocalDataSourceImpl.kt
@@ -15,8 +15,9 @@ class ScannedDeviceLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun insertAll(deviceList: List<ScannedDeviceEntity>) {
-        printLog("insertDeviceList ScannedDeviceLocalDataSourceImpl")
+        printLog("🔥 insertDeviceList ScannedDeviceLocalDataSourceImpl - ${deviceList.size} devices", "dbDebug")
         dao.insertAll(deviceList)
+        printLog("✅ DAO insertAll completed", "dbDebug")
     }
 
     override fun getAll(): Flow<List<ScannedDeviceEntity>> = dao.getAll()

--- a/app/src/main/java/com/example/bluetoothtracker/data/repoImpl/BluetoothRepositoryImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/repoImpl/BluetoothRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.example.bluetoothtracker.data.repoImpl
 import com.example.bluetoothtracker.data.datasource.BluetoothDeviceTracker
 import com.example.bluetoothtracker.data.model.BluetoothScanResult
 import com.example.bluetoothtracker.domain.repository.BluetoothRepository
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
 class BluetoothRepositoryImpl @Inject constructor(private val bluetoothManager: BluetoothDeviceTracker) :

--- a/app/src/main/java/com/example/bluetoothtracker/data/repoImpl/ScannedDeviceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/data/repoImpl/ScannedDeviceRepositoryImpl.kt
@@ -21,8 +21,9 @@ class ScannedDeviceRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertDeviceList(deviceList: List<BluetoothScanResult>) {
-        printLog("insertDeviceList ScannedDeviceRepositoryImpl")
+        printLog("🔥 insertDeviceList ScannedDeviceRepositoryImpl - ${deviceList.size} devices", "dbDebug")
         localDataSource.insertAll(deviceList.toEntityList())
+        printLog("✅ insertDeviceList completed", "dbDebug")
     }
 
     override fun getAllDevices(): Flow<List<Device>> {

--- a/app/src/main/java/com/example/bluetoothtracker/di/BluetoothModule.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/di/BluetoothModule.kt
@@ -12,8 +12,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import jakarta.inject.Qualifier
-import jakarta.inject.Singleton
+import javax.inject.Qualifier
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/app/src/main/java/com/example/bluetoothtracker/di/BluetoothModule.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/di/BluetoothModule.kt
@@ -27,6 +27,7 @@ annotation class ApplicationScope
 object BluetoothModule {
 
     @Provides
+    @Singleton
     @ApplicationScope
     fun provideApplicationScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/app/src/main/java/com/example/bluetoothtracker/di/DataBaseModule.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/di/DataBaseModule.kt
@@ -23,6 +23,7 @@ import jakarta.inject.Singleton
 object DatabaseModule {
 
     @Provides
+    @Singleton
     fun provideDatabase(@ApplicationContext context: Context): ScannedDeviceDatabase {
         return Room.databaseBuilder(
             context,
@@ -32,16 +33,19 @@ object DatabaseModule {
     }
 
     @Provides
+    @Singleton
     fun provideBluetoothDeviceDao(db: ScannedDeviceDatabase): ScannedDeviceDao {
         return db.deviceDao()
     }
 
     @Provides
+    @Singleton
     fun provideScannedDeviceRepository(
         localDataSource: ScannedDeviceLocalDataSource
     ): ScannedDeviceRepository = ScannedDeviceRepositoryImpl(localDataSource)
 
     @Provides
+    @Singleton
     fun provideScannedDeviceLocalDataSource(
         dao: ScannedDeviceDao
     ): ScannedDeviceLocalDataSource = ScannedDeviceLocalDataSourceImpl(dao)

--- a/app/src/main/java/com/example/bluetoothtracker/domain/interactor/BluetoothInteractor.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/interactor/BluetoothInteractor.kt
@@ -4,7 +4,7 @@ import com.example.bluetoothtracker.domain.usecase.GetAllDevicesUseCase
 import com.example.bluetoothtracker.domain.usecase.InsertScannedDeviceUseCase
 import com.example.bluetoothtracker.domain.usecase.StartScnBluetoothUseCase
 import com.example.bluetoothtracker.domain.usecase.StopScnBluetoothUseCase
-import jakarta.inject.Inject
+import javax.inject.Inject
 
 data class BluetoothInteractor @Inject constructor(
     val startScnBluetooth: StartScnBluetoothUseCase,

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -17,14 +17,26 @@ class InsertScannedDeviceUseCase @Inject constructor(
     operator fun invoke() {
         printLog("startCollectingScansAndInsertToDb", "usecase_debug")
         
+        // Test the repository connection first
+        val flow = bluetoothRepository.scannedDevicesFlow()
+        printLog("Successfully got scannedDevicesFlow from repository: $flow", "usecase_debug")
+        
         // Launch collection in the application scope to keep it running
         appScope.launch(Dispatchers.IO) {
-            printLog("Starting to collect from scannedDevicesFlow", "usecase_debug")
-            bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
-                printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
-                printLog("2 collect devices: $deviceList", "usecase_debug")
-                scannedDeviceRepository.insertDeviceList(deviceList)
-                printLog("Successfully inserted ${deviceList.size} devices to database", "usecase_debug")
+            try {
+                printLog("Starting to collect from scannedDevicesFlow", "usecase_debug")
+                bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
+                    printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
+                    printLog("2 collect devices: $deviceList", "usecase_debug")
+                    if (deviceList.isNotEmpty()) {
+                        scannedDeviceRepository.insertDeviceList(deviceList)
+                        printLog("Successfully inserted ${deviceList.size} devices to database", "usecase_debug")
+                    } else {
+                        printLog("Received empty device list from SharedFlow", "usecase_debug")
+                    }
+                }
+            } catch (e: Exception) {
+                printLog("Error in collection: ${e.message}", "usecase_debug")
             }
         }
     }

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -31,10 +31,16 @@ class InsertScannedDeviceUseCase @Inject constructor(
         printLog("Successfully got scannedDevicesFlow from repository: $flow", "usecase_debug")
         
         // Launch collection in the application scope to keep it running
+        printLog("About to launch collection coroutine", "usecase_debug")
         collectionJob = appScope.launch(Dispatchers.IO) {
+            printLog("INSIDE collection coroutine - coroutine started", "usecase_debug")
             try {
-                printLog("Starting to collect from scannedDevicesFlow - COLLECTOR IS NOW ACTIVE", "usecase_debug")
-                bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
+                printLog("About to get scannedDevicesFlow", "usecase_debug")
+                val flow = bluetoothRepository.scannedDevicesFlow()
+                printLog("Got flow: $flow", "usecase_debug")
+                
+                printLog("About to start collecting - COLLECTOR IS NOW ACTIVE", "usecase_debug")
+                flow.collect { deviceList ->
                     printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
                     printLog("2 collect devices: $deviceList", "usecase_debug")
                     if (deviceList.isNotEmpty()) {
@@ -46,7 +52,9 @@ class InsertScannedDeviceUseCase @Inject constructor(
                 }
             } catch (e: Exception) {
                 printLog("Error in collection: ${e.message}", "usecase_debug")
+                printLog("Exception stacktrace: ${e.stackTrace.contentToString()}", "usecase_debug")
             }
         }
+        printLog("Collection coroutine launched, job: $collectionJob", "usecase_debug")
     }
 }

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -14,7 +14,16 @@ class InsertScannedDeviceUseCase @Inject constructor(
     private val bluetoothRepository: BluetoothRepository,
     private val scannedDeviceRepository: ScannedDeviceRepository
 ) {
+    
+    private var collectionJob: Job? = null
+    
     operator fun invoke() {
+        // Prevent multiple collections
+        if (collectionJob?.isActive == true) {
+            printLog("Collection already active, skipping", "usecase_debug")
+            return
+        }
+        
         printLog("startCollectingScansAndInsertToDb", "usecase_debug")
         
         // Test the repository connection first
@@ -22,9 +31,9 @@ class InsertScannedDeviceUseCase @Inject constructor(
         printLog("Successfully got scannedDevicesFlow from repository: $flow", "usecase_debug")
         
         // Launch collection in the application scope to keep it running
-        appScope.launch(Dispatchers.IO) {
+        collectionJob = appScope.launch(Dispatchers.IO) {
             try {
-                printLog("Starting to collect from scannedDevicesFlow", "usecase_debug")
+                printLog("Starting to collect from scannedDevicesFlow - COLLECTOR IS NOW ACTIVE", "usecase_debug")
                 bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
                     printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
                     printLog("2 collect devices: $deviceList", "usecase_debug")

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -22,43 +22,46 @@ class InsertScannedDeviceUseCase @Inject constructor(
     private var collectionJob: Job? = null
     
     operator fun invoke() {
+        printLog("=== USECASE INVOKE STARTED ===", "checkDebug")
+        
         // Prevent multiple collections
         if (collectionJob?.isActive == true) {
-            printLog("Collection already active, skipping", "usecase_debug")
+            printLog("Collection already active, skipping", "checkDebug")
             return
         }
         
-        printLog("startCollectingScansAndInsertToDb", "usecase_debug")
+        printLog("startCollectingScansAndInsertToDb2 ${appScope.isActive}", "checkDebug")
         
         // Test the repository connection first
         val flow = bluetoothRepository.scannedDevicesFlow()
-        printLog("Successfully got scannedDevicesFlow from repository: $flow", "usecase_debug")
+        printLog("Successfully got scannedDevicesFlow from repository: $flow", "checkDebug")
         
         // Launch collection in the application scope to keep it running
-        printLog("About to launch collection coroutine", "usecase_debug")
+        printLog("About to launch collection coroutine", "checkDebug")
         collectionJob = appScope.launch(Dispatchers.IO) {
-            printLog("INSIDE collection coroutine - coroutine started", "usecase_debug")
+            printLog("🚀 INSIDE COROUTINE - COROUTINE STARTED!", "checkDebug")
             try {
-                printLog("About to get scannedDevicesFlow", "usecase_debug")
-                val flow = bluetoothRepository.scannedDevicesFlow()
-                printLog("Got flow: $flow", "usecase_debug")
+                printLog("About to get scannedDevicesFlow", "checkDebug")
+                val flowInside = bluetoothRepository.scannedDevicesFlow()
+                printLog("Got flow inside coroutine: $flowInside", "checkDebug")
                 
-                printLog("About to start collecting - COLLECTOR IS NOW ACTIVE", "usecase_debug")
-                flow.collect { deviceList ->
-                    printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
-                    printLog("2 collect devices: $deviceList", "usecase_debug")
+                printLog("🎯 ABOUT TO START COLLECTING - COLLECTOR IS NOW ACTIVE!", "checkDebug")
+                flowInside.collect { deviceList ->
+                    printLog("🎉 COLLECT SUCCESS: ${deviceList.size} devices", "checkDebug")
+                    printLog("🎉 COLLECT DEVICES: $deviceList", "checkDebug")
                     if (deviceList.isNotEmpty()) {
                         scannedDeviceRepository.insertDeviceList(deviceList)
-                        printLog("Successfully inserted ${deviceList.size} devices to database", "usecase_debug")
+                        printLog("✅ Successfully inserted ${deviceList.size} devices to database", "checkDebug")
                     } else {
-                        printLog("Received empty device list from SharedFlow", "usecase_debug")
+                        printLog("📭 Received empty device list from SharedFlow", "checkDebug")
                     }
                 }
             } catch (e: Exception) {
-                printLog("Error in collection: ${e.message}", "usecase_debug")
-                printLog("Exception stacktrace: ${e.stackTrace.contentToString()}", "usecase_debug")
+                printLog("❌ Error in collection: ${e.message}", "checkDebug")
+                printLog("❌ Exception stacktrace: ${e.stackTrace.contentToString()}", "checkDebug")
             }
         }
-        printLog("Collection coroutine launched, job: $collectionJob", "usecase_debug")
+        printLog("Collection coroutine launched, job: $collectionJob", "checkDebug")
+        printLog("=== USECASE INVOKE FINISHED ===", "checkDebug")
     }
 }

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -6,14 +6,18 @@ import com.example.bluetoothtracker.domain.repository.ScannedDeviceRepository
 import com.example.bluetoothtracker.presentation.utils.printLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class InsertScannedDeviceUseCase @Inject constructor(
-    @ApplicationScope private val appScope: CoroutineScope,
     private val bluetoothRepository: BluetoothRepository,
     private val scannedDeviceRepository: ScannedDeviceRepository
 ) {
+    
+    // Use GlobalScope temporarily to test if injection was the issue
+    private val appScope: CoroutineScope = GlobalScope
     
     private var collectionJob: Job? = null
     

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -7,7 +7,7 @@ import com.example.bluetoothtracker.presentation.utils.printLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+import jakarta.inject.Inject
 
 class InsertScannedDeviceUseCase @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope,

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -14,13 +14,18 @@ class InsertScannedDeviceUseCase @Inject constructor(
     private val bluetoothRepository: BluetoothRepository,
     private val scannedDeviceRepository: ScannedDeviceRepository
 ) {
-     suspend  operator fun invoke() {
-        printLog("startCollectingScansAndInsertToDb")
-
-           bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
-               printLog("2 collect: $deviceList")
-               scannedDeviceRepository.insertDeviceList(deviceList)
-           }
-
+    operator fun invoke() {
+        printLog("startCollectingScansAndInsertToDb", "usecase_debug")
+        
+        // Launch collection in the application scope to keep it running
+        appScope.launch(Dispatchers.IO) {
+            printLog("Starting to collect from scannedDevicesFlow", "usecase_debug")
+            bluetoothRepository.scannedDevicesFlow().collect { deviceList ->
+                printLog("2 collect: ${deviceList.size} devices", "usecase_debug")
+                printLog("2 collect devices: $deviceList", "usecase_debug")
+                scannedDeviceRepository.insertDeviceList(deviceList)
+                printLog("Successfully inserted ${deviceList.size} devices to database", "usecase_debug")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/domain/usecase/InsertScannedDeviceUseCase.kt
@@ -7,7 +7,7 @@ import com.example.bluetoothtracker.presentation.utils.printLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import jakarta.inject.Inject
+import javax.inject.Inject
 
 class InsertScannedDeviceUseCase @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope,

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
@@ -35,6 +35,7 @@ class MainActivity : ComponentActivity() {
 
     private lateinit var permissionManager: PermissionManager
     private lateinit var bluetoothStateObserver: BluetoothStateObserver
+    private lateinit var locationServicesManager: LocationServicesManager
 
     /*
     * registerForActivityResult() must be called before the activity is STARTED, usually in onCreate().
@@ -60,6 +61,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         initObservers()
         addPermissionObserver()
+        initLocationServicesManager()
         lifecycleScope.launch{
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.event.collect { event ->
@@ -68,7 +70,12 @@ class MainActivity : ComponentActivity() {
                             permissionManager.requestBluetoothPermissions()
                         }
                         HomeEvent.RequestEnableBluetooth -> {
-                            bluetoothStateObserver.requestEnableBluetooth()
+                            if (::bluetoothStateObserver.isInitialized) {
+                                bluetoothStateObserver.requestEnableBluetooth()
+                            }
+                        }
+                        HomeEvent.RequestEnableLocationServices -> {
+                            locationServicesManager.promptEnableLocationServices()
                         }
                     }
                 }
@@ -126,6 +133,10 @@ class MainActivity : ComponentActivity() {
                 },
             )
         )
+    }
+
+    private fun initLocationServicesManager() {
+        locationServicesManager = LocationServicesManager(this)
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
@@ -137,6 +137,19 @@ class MainActivity : ComponentActivity() {
 
     private fun initLocationServicesManager() {
         locationServicesManager = LocationServicesManager(this)
+        // Check initial location services state
+        checkLocationServicesState()
+    }
+    
+    private fun checkLocationServicesState() {
+        val isEnabled = locationServicesManager.isLocationEnabled()
+        viewModel.onAction(HomeAction.OnLocationServicesChange(isEnabled))
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Re-check location services when returning from settings
+        checkLocationServicesState()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/app/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.example.bluetoothtracker.presentation.common.BluetoothRequirementsManager
 import com.example.bluetoothtracker.presentation.common.BluetoothStateObserver
 import com.example.bluetoothtracker.presentation.common.PermissionManager
 import com.example.bluetoothtracker.presentation.screen.home.HomeAction
@@ -34,8 +35,8 @@ class MainActivity : ComponentActivity() {
     private val viewModel: HomeViewModel by viewModels()
 
     private lateinit var permissionManager: PermissionManager
-    private lateinit var bluetoothStateObserver: BluetoothStateObserver
-    private lateinit var locationServicesManager: LocationServicesManager
+    private var bluetoothStateObserver: BluetoothStateObserver? = null
+    private lateinit var requirementsManager: BluetoothRequirementsManager
 
     /*
     * registerForActivityResult() must be called before the activity is STARTED, usually in onCreate().
@@ -61,21 +62,19 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         initObservers()
         addPermissionObserver()
-        initLocationServicesManager()
+        initRequirementsManager()
         lifecycleScope.launch{
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.event.collect { event ->
                     when (event) {
                         HomeEvent.RequestBluetoothPermission -> {
-                            permissionManager.requestBluetoothPermissions()
+                            requirementsManager.requestPermissions()
                         }
                         HomeEvent.RequestEnableBluetooth -> {
-                            if (::bluetoothStateObserver.isInitialized) {
-                                bluetoothStateObserver.requestEnableBluetooth()
-                            }
+                            requirementsManager.requestEnableBluetooth()
                         }
                         HomeEvent.RequestEnableLocationServices -> {
-                            locationServicesManager.promptEnableLocationServices()
+                            requirementsManager.requestEnableLocationServices()
                         }
                     }
                 }
@@ -123,33 +122,41 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun addBluetoothObserver() {
-        lifecycle.addObserver(
-            observer = BluetoothStateObserver(
-                activity = this,
-                btAdapter = bluetoothAdapter,
-                btEnableResultLauncher = btEnableResultLauncher,
-                onBluetoothState = { isEnabled ->
-                    viewModel.onAction(HomeAction.OnBluetoothStateChange(bluetoothState = isEnabled))
-                },
-            )
+        bluetoothStateObserver = BluetoothStateObserver(
+            activity = this,
+            btAdapter = bluetoothAdapter,
+            btEnableResultLauncher = btEnableResultLauncher,
+            onBluetoothState = { isEnabled ->
+                viewModel.onAction(HomeAction.OnBluetoothStateChange(bluetoothState = isEnabled))
+                // Re-check all requirements when Bluetooth state changes
+                requirementsManager.checkAllRequirements()
+            }
         )
+        lifecycle.addObserver(bluetoothStateObserver!!)
     }
 
-    private fun initLocationServicesManager() {
-        locationServicesManager = LocationServicesManager(this)
-        // Check initial location services state
-        checkLocationServicesState()
-    }
-    
-    private fun checkLocationServicesState() {
-        val isEnabled = locationServicesManager.isLocationEnabled()
-        viewModel.onAction(HomeAction.OnLocationServicesChange(isEnabled))
+    private fun initRequirementsManager() {
+        requirementsManager = BluetoothRequirementsManager(
+            activity = this,
+            permissionManager = permissionManager,
+            bluetoothStateObserver = bluetoothStateObserver,
+            onRequirementsChange = { state ->
+                // Update ViewModel with all states at once
+                viewModel.onAction(HomeAction.OnPermissionGrantedChange(state.permissionsGranted))
+                viewModel.onAction(HomeAction.OnBluetoothStateChange(state.bluetoothEnabled))
+                viewModel.onAction(HomeAction.OnLocationServicesChange(state.locationServicesEnabled))
+            }
+        )
+        // Check initial state
+        requirementsManager.checkAllRequirements()
     }
 
     override fun onResume() {
         super.onResume()
-        // Re-check location services when returning from settings
-        checkLocationServicesState()
+        // Re-check all requirements when returning from settings
+        if (::requirementsManager.isInitialized) {
+            requirementsManager.checkAllRequirements()
+        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/common/BluetoothRequirementsManager.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/common/BluetoothRequirementsManager.kt
@@ -1,0 +1,93 @@
+package com.example.bluetoothtracker.presentation.common
+
+import android.bluetooth.BluetoothAdapter
+import android.content.Context
+import android.content.Intent
+import android.location.LocationManager
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+
+class BluetoothRequirementsManager(
+    private val activity: ComponentActivity,
+    private val permissionManager: PermissionManager,
+    private val bluetoothStateObserver: BluetoothStateObserver?,
+    private val onRequirementsChange: (RequirementsState) -> Unit
+) {
+    
+    data class RequirementsState(
+        val permissionsGranted: Boolean = false,
+        val bluetoothEnabled: Boolean = false,
+        val locationServicesEnabled: Boolean = false
+    ) {
+        val allRequirementsMet: Boolean
+            get() = permissionsGranted && bluetoothEnabled && locationServicesEnabled
+            
+        val nextRequiredAction: RequiredAction?
+            get() = when {
+                !permissionsGranted -> RequiredAction.GRANT_PERMISSIONS
+                !bluetoothEnabled -> RequiredAction.ENABLE_BLUETOOTH
+                !locationServicesEnabled -> RequiredAction.ENABLE_LOCATION_SERVICES
+                else -> null
+            }
+    }
+    
+    enum class RequiredAction {
+        GRANT_PERMISSIONS,
+        ENABLE_BLUETOOTH,
+        ENABLE_LOCATION_SERVICES
+    }
+    
+    fun checkAllRequirements(): RequirementsState {
+        val state = RequirementsState(
+            permissionsGranted = permissionManager.hasBluetoothPermissions(),
+            bluetoothEnabled = isBluetoothEnabled(),
+            locationServicesEnabled = isLocationServicesEnabled()
+        )
+        
+        onRequirementsChange(state)
+        return state
+    }
+    
+    fun requestPermissions() {
+        permissionManager.requestBluetoothPermissions()
+    }
+    
+    fun requestEnableBluetooth() {
+        bluetoothStateObserver?.requestEnableBluetooth()
+    }
+    
+    fun requestEnableLocationServices() {
+        val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+        activity.startActivity(intent)
+    }
+    
+    fun handleNextRequiredAction(): Boolean {
+        val state = checkAllRequirements()
+        return when (state.nextRequiredAction) {
+            RequiredAction.GRANT_PERMISSIONS -> {
+                requestPermissions()
+                true
+            }
+            RequiredAction.ENABLE_BLUETOOTH -> {
+                requestEnableBluetooth()
+                true
+            }
+            RequiredAction.ENABLE_LOCATION_SERVICES -> {
+                requestEnableLocationServices()
+                true
+            }
+            null -> false // All requirements met
+        }
+    }
+    
+    private fun isBluetoothEnabled(): Boolean {
+        val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter()
+        return bluetoothAdapter?.isEnabled == true
+    }
+    
+    private fun isLocationServicesEnabled(): Boolean {
+        val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || 
+               locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+    }
+}

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/common/LocationServicesManager.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/common/LocationServicesManager.kt
@@ -1,0 +1,23 @@
+package com.example.bluetoothtracker.presentation.common
+
+import android.content.Context
+import android.content.Intent
+import android.location.LocationManager
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+
+class LocationServicesManager(
+    private val activity: ComponentActivity
+) {
+    
+    fun isLocationEnabled(): Boolean {
+        val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || 
+               locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+    }
+    
+    fun promptEnableLocationServices() {
+        val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+        activity.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/common/LocationServicesManager.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/common/LocationServicesManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.location.LocationManager
 import android.provider.Settings
 import androidx.activity.ComponentActivity
+import com.example.bluetoothtracker.presentation.utils.printLog
 
 class LocationServicesManager(
     private val activity: ComponentActivity
@@ -17,7 +18,23 @@ class LocationServicesManager(
     }
     
     fun promptEnableLocationServices() {
+        printLog("Opening location services settings", "locationDebug")
         val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
         activity.startActivity(intent)
     }
+    
+    fun getLocationStatus(): LocationStatus {
+        val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return LocationStatus(
+            gpsEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER),
+            networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER),
+            anyEnabled = isLocationEnabled()
+        )
+    }
+    
+    data class LocationStatus(
+        val gpsEnabled: Boolean,
+        val networkEnabled: Boolean, 
+        val anyEnabled: Boolean
+    )
 }

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/common/PermissionsList.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/common/PermissionsList.kt
@@ -4,26 +4,34 @@ import android.Manifest
 import android.os.Build
 
 val permissionsList = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    // Android 12+ (API 31+)
     listOf(
-        Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT,
-        Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.ACCESS_FINE_LOCATION
     )
 } else {
+    // Android 11 and below (API 30 and below)
     listOf(
+        Manifest.permission.BLUETOOTH,
         Manifest.permission.BLUETOOTH_ADMIN,
-        Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
+        Manifest.permission.ACCESS_FINE_LOCATION
     )
 }
 
 val permissionsArray = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    // Android 12+ (API 31+)
     arrayOf(
-        Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT,
-        Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.ACCESS_FINE_LOCATION
     )
 } else {
+    // Android 11 and below (API 30 and below)
     arrayOf(
+        Manifest.permission.BLUETOOTH,
         Manifest.permission.BLUETOOTH_ADMIN,
-        Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
+        Manifest.permission.ACCESS_FINE_LOCATION
     )
 }
 

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeAction.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeAction.kt
@@ -3,6 +3,8 @@ package com.example.bluetoothtracker.presentation.screen.home
 sealed interface HomeAction {
     data class ShowPermissionAlertDialog(val show : Boolean) :HomeAction
     data class ShowPermissionDeniedDialog(val show : Boolean) :HomeAction
+    data class ShowLocationServicesDialog(val show : Boolean) :HomeAction
     data class OnPermissionGrantedChange(val permissionGranted: Boolean) : HomeAction
     data class OnBluetoothStateChange(val bluetoothState: Boolean) : HomeAction
+    data class OnLocationServicesChange(val locationServicesEnabled: Boolean) : HomeAction
 }

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeEvent.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeEvent.kt
@@ -4,4 +4,5 @@ package com.example.bluetoothtracker.presentation.screen.home
 sealed class HomeEvent {
     data object RequestBluetoothPermission : HomeEvent()
     data object RequestEnableBluetooth : HomeEvent()
+    data object RequestEnableLocationServices : HomeEvent()
 }

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeScreen.kt
@@ -28,13 +28,44 @@ fun HomeScreenRoot(viewModel: HomeViewModel, modifier: Modifier = Modifier) {
     val state by viewModel.homeStateValue.collectAsStateWithLifecycle()
 
 
-    LaunchedEffect(key1 = state.permissionGranted, key2 = state.bluetoothState) {
-        printLog("LaunchedEffect  $state")
-        if (state.permissionGranted == true && state.bluetoothState == true) {
-            printLog("LaunchedEffect permissions granted ")
-            viewModel.startScan()
-        } else if (state.permissionGranted == false || state.bluetoothState == false) {
-            viewModel.stopScan()
+    LaunchedEffect(key1 = state.permissionGranted, key2 = state.bluetoothState, key3 = state.locationServicesEnabled) {
+        printLog("LaunchedEffect state: $state", "flowDebug")
+        
+        when {
+            // Step 1: Check permissions first
+            state.permissionGranted == false -> {
+                printLog("❌ Permissions not granted", "flowDebug")
+                viewModel.stopScan()
+            }
+            state.permissionGranted == null -> {
+                printLog("⏳ Permissions unknown, waiting...", "flowDebug")
+            }
+            
+            // Step 2: Check Bluetooth (permissions OK)
+            state.bluetoothState == false -> {
+                printLog("❌ Bluetooth disabled", "flowDebug") 
+                viewModel.stopScan()
+            }
+            state.bluetoothState == null -> {
+                printLog("⏳ Bluetooth state unknown, waiting...", "flowDebug")
+            }
+            
+            // Step 3: Check Location Services (permissions + BT OK)
+            state.locationServicesEnabled == false -> {
+                printLog("❌ Location services disabled", "flowDebug")
+                viewModel.stopScan()
+            }
+            state.locationServicesEnabled == null -> {
+                printLog("⏳ Location services unknown, waiting...", "flowDebug")
+            }
+            
+            // Step 4: All good - Start scanning!
+            state.permissionGranted == true && 
+            state.bluetoothState == true && 
+            state.locationServicesEnabled == true -> {
+                printLog("✅ All requirements met - Starting scan!", "flowDebug")
+                viewModel.startScan()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeState.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeState.kt
@@ -6,8 +6,10 @@ import com.example.bluetoothtracker.domain.data.Device
 data class HomeState(
     val showPermissionAlertDialog : Boolean = false,
     val showPermissionDeniedDialog : Boolean = false,
+    val showLocationServicesDialog : Boolean = false,
     val permissionGranted : Boolean? = null,
     val bluetoothState : Boolean? = null,
+    val locationServicesEnabled : Boolean? = null,
     val onLineDevicesList : List<Device> = emptyList(),
     val offlineDevicesList : List<Device> = emptyList()
 )

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
@@ -27,8 +27,8 @@ class HomeViewModel @Inject constructor(
         bluetoothInteractor.insertScannedDeviceUseCase()
         viewModelScope.launch {
             bluetoothInteractor.getAllDevicesUseCase().collect { list ->
-                printLog("getAllDevicesUseCase: size ${list.size}", "uicheck")
-                printLog("getAllDevicesUseCase: $list", "uicheck")
+                printLog("🔔 DATABASE CHANGED! getAllDevicesUseCase: size ${list.size}", "dbDebug")
+                printLog("🔔 DEVICE LIST: $list", "dbDebug")
                 val sortedList = list.sortedByDescending { item -> item.rssi }
                 homeState.update {
                     it.copy(

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
@@ -23,7 +23,8 @@ class HomeViewModel @Inject constructor(
 
     init {
         printLog("init vm")
-        //  viewModelScope.launch { bluetoothInteractor.insertScannedDeviceUseCase() }
+        // Start collecting scanned devices and inserting them to the database
+        viewModelScope.launch { bluetoothInteractor.insertScannedDeviceUseCase() }
         viewModelScope.launch {
             bluetoothInteractor.getAllDevicesUseCase().collect { list ->
                 printLog("getAllDevicesUseCase: size ${list.size}", "uicheck")

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
@@ -23,7 +23,7 @@ class HomeViewModel @Inject constructor(
 
     init {
         printLog("init vm")
-        // Start collecting scanned devices and inserting them to the database
+        // Start collecting scanned devices and inserting them to the database FIRST
         bluetoothInteractor.insertScannedDeviceUseCase()
         viewModelScope.launch {
             bluetoothInteractor.getAllDevicesUseCase().collect { list ->

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
@@ -24,7 +24,7 @@ class HomeViewModel @Inject constructor(
     init {
         printLog("init vm")
         // Start collecting scanned devices and inserting them to the database
-        viewModelScope.launch { bluetoothInteractor.insertScannedDeviceUseCase() }
+        bluetoothInteractor.insertScannedDeviceUseCase()
         viewModelScope.launch {
             bluetoothInteractor.getAllDevicesUseCase().collect { list ->
                 printLog("getAllDevicesUseCase: size ${list.size}", "uicheck")

--- a/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothtracker/presentation/screen/home/HomeViewModel.kt
@@ -65,8 +65,12 @@ class HomeViewModel @Inject constructor(
                 )
             }
 
+            is HomeAction.ShowLocationServicesDialog -> homeState.update {
+                it.copy(showLocationServicesDialog = action.show)
+            }
             is HomeAction.OnPermissionGrantedChange -> homeState.update { it.copy(permissionGranted = action.permissionGranted) }
             is HomeAction.OnBluetoothStateChange -> homeState.update { it.copy(bluetoothState = action.bluetoothState) }
+            is HomeAction.OnLocationServicesChange -> homeState.update { it.copy(locationServicesEnabled = action.locationServicesEnabled) }
         }
     }
 


### PR DESCRIPTION
Fix Bluetooth scan data collection, database observation, and permission handling.

Previously, Bluetooth scan results were not collected because `BluetoothDeviceTrackerImpl` was not a singleton, causing emitter and collector to operate on different instances. Database changes were not observed by the UI as Room database and DAO providers were also not singletons. Additionally, Bluetooth permissions were updated to correctly handle different Android SDK versions, including `maxSdkVersion` and `BLUETOOTH` for older APIs.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1511e33b-d22c-4d85-b778-7629571bcb22) · [Cursor](https://cursor.com/background-agent?bcId=bc-1511e33b-d22c-4d85-b778-7629571bcb22)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)